### PR TITLE
Fix wrong value being exported in relative labels.

### DIFF
--- a/disassembler/autoLabel.py
+++ b/disassembler/autoLabel.py
@@ -47,7 +47,7 @@ class RelativeLabel:
     def __str__(self):
         label = self.memory.getLabel(self.target)
         if label is None:
-            label = f"${self.address}"
+            label = f"${self.target:x}"
         else:
             label = str(label)
         offset = self.address - self.target


### PR DESCRIPTION
The latest fix to relative labels had 2 issues.

1: The address was being exported as decimal rather than hexadecimal.

2: `self.address` was used where `self.target` should have been. 

With these fixes, my disassembly matches the target checksum again and all the warnings are gone. 

Here are some screenshots of the current broken state:
<img width="1192" height="74" alt="Screenshot 2026-02-17 000957" src="https://github.com/user-attachments/assets/c964581e-95fa-4197-9e6e-e4badda2b9e9" />

<img width="1009" height="710" alt="Screenshot 2026-02-16 235823" src="https://github.com/user-attachments/assets/ba8d3668-71fb-414d-9d15-94e874d8c9ce" />