### PR TITLE
Add initial wram bank support

### DIFF
--- a/disassembler/assemblyFile.py
+++ b/disassembler/assemblyFile.py
@@ -1,6 +1,6 @@
 import os
 from memory.rom import RomMemory
-from memory.ram import WRamMemory
+from memory.ram import WRamMemoryBanked
 
 
 class AssemblyFile:
@@ -49,6 +49,10 @@ class AssemblyFile:
             else:
                 self.__file.write("SECTION \"%s\", ROMX[$%04x], BANK[$%02x]\n" % (sectionname, self.addr, self.__memory.bankNumber))
             self.__addr_prefix = "%02x:" % (self.__memory.bankNumber)
+        elif isinstance(self.__memory, WRamMemoryBanked) and self.__memory.bankNumber != 0:
+            if addr is None:
+                self.__file.write("SECTION \"wram%01x\", WRAMX[$%04x], BANK[$%01x]\n" % (self.__memory.bankNumber, self.__memory.base_address, self.__memory.bankNumber))
+            self.__addr_prefix = ""
         else:
             if addr is None:
                 self.__file.write("SECTION \"%s\", %s[$%04x]\n" % (self.__memory.type.lower(), self.__memory.type.upper(), self.__memory.base_address))

--- a/disassembler/disassembler.py
+++ b/disassembler/disassembler.py
@@ -13,9 +13,10 @@ from annotation.simple import DataBlock
 
 
 class Disassembler:
-    def __init__(self, rom):
+    def __init__(self, rom, wram_banks):
         self.__rom = rom
-        RomInfo.init(rom)
+        self.wram_banks = wram_banks
+        RomInfo.init(rom, wram_banks)
 
     def readSources(self, path):
         if os.path.exists(os.path.join(path, "src")):
@@ -97,7 +98,10 @@ class Disassembler:
         self.__exportRam(f, RomInfo.getHRam())
         self.__exportRam(f, RomInfo.getVRam())
         self.__exportRam(f, RomInfo.getSRam())
-        
+        for wramBankNum in range(1, self.wram_banks):
+            wramBankFile = AssemblyFile(path, os.path.join("src", "memory%01X.asm" % wramBankNum))
+            self.__exportRam(wramBankFile, RomInfo.getWRam(wramBankNum))
+
         os.makedirs(os.path.join(path, "src", "include"), exist_ok=True)
         macro_file = open(os.path.join(path, "src", "include", "macros.inc"), "wt")
         for macro, contents in sorted(RomInfo.macros.items()):

--- a/disassembler/main.py
+++ b/disassembler/main.py
@@ -18,6 +18,7 @@ from annotation import sdcc
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("rom", type=str, nargs="?")
+    parser.add_argument("--wram-banks", type=int, default=1)
     parser.add_argument("--instrumentation", action='append', default=[])
     parser.add_argument("--source")
     parser.add_argument("--output", type=str, required=False)
@@ -67,7 +68,7 @@ if __name__ == "__main__":
 
     if args.rom:
         rom = ROM(args.rom)
-        disassembler = Disassembler(rom)
+        disassembler = Disassembler(rom, args.wram_banks)
         disassembler.readSources(args.source if args.source else args.output)
         for instrumentation_file in args.instrumentation:
             processInstrumentation(instrumentation_file)

--- a/disassembler/memory/ram.py
+++ b/disassembler/memory/ram.py
@@ -27,11 +27,19 @@ class WRamMemory(Memory):
 
 class WRamMemoryBanked(Memory):
     def __init__(self, bank):
-        super().__init__("wram0" if bank == 0 else "wramx", 0x1000, base_address=0xC000 + bank * 0x1000)
+        super().__init__("wram0" if bank == 0 else "wramx", 0x1000, base_address=0xC000 if bank == 0 else 0xD000)
+        self.__bank = bank
+
+    @property
+    def bankNumber(self):
+        return self.__bank
 
     def addAutoLabel(self, addr, source, type):
         if self.getLabel(addr) == None:
-            self.addLabel(addr, "w%04X" % (addr))
+            if self.__bank == 0:
+                self.addLabel(addr, "w%04X" % (addr))
+            else:
+                self.addLabel(addr, "w%01X_%04X" % (self.__bank, addr))
 
 class OAMMemory(Memory):
     def __init__(self):

--- a/disassembler/sourceReader.py
+++ b/disassembler/sourceReader.py
@@ -49,6 +49,9 @@ class SourceReader:
             self.__memory = RomInfo.romBank(bank_nr)
         elif section_type == "WRAM0":
             self.__memory = RomInfo.getWRam()
+        elif section_type == "WRAMX":
+            wram_bank_nr = int(re.search(r"BANK\[\$([0-9a-f]+)\]", line.strip().split(",")[2]).group(1), 16)
+            self.__memory = RomInfo.getWRam(wram_bank_nr)
         elif section_type == "SRAM":
             self.__memory = RomInfo.getSRam()
         elif section_type == "HRAM":


### PR DESCRIPTION
This PR implements basic support for banked WRAM. A command line argument `--wram-banks #` is introduced. If it is not supplied, the behavior of the disassembler is unchanged. 

__What this can't do (yet):__
* Instrumentation is NOT changed in this PR.
* This PR does NOT introduce a new annotation analogous to `;@bank` that would let the user indicate the active WRAM bank of an instruction. 

Without these, there is NO way for the disassembler to know what the active WRAM bank is for any instruction. In this iteration, _it always assumes WRAM bank 1 is active_. This is potentially inaccurate, but is no worse than the current situation where there is exclusively a WRAM0 anyway. 

* The included Makefile will fail to link a disassembly with multiple WRAM banks. The user must manually remove the `-w` flag from `rgblink` to correct this.

__What this _can_ do:__

The disassembler will now create multiple `memory#.asm` files for the WRAM banks. Without any signal to do stuff with the files beyond WRAM bank 1, the other files will just be a pile of 4096 unknown, unlabeled bytes. But while the disassembler will never automatically label addresses in higher WRAM banks in its current form, it should support doing so via manually added labels or custom plugins.

To accommodate multiple WRAM banks, the labels of type `wD###` are changed to `w#_D###` when using the `--wram-banks` argument. 

You can see an example of the effect of supplying `--wram-banks 8` in the below commit of my project:
https://github.com/HaychDeeHD/HamHamsUniteDisassembly/commit/40f1ebc54538711d57460c2c289ea07d4958925f

__Logical order to review the changes for easiest understanding:__
1. `main.py`
2. `disassembler.py`
3. `romInfo.py`
4. `ram.py`
5. `assemblyFile.py`
6. `sourceReader.py`

Please let me know if you have any feedback about the approach, implementation, style, or anything else!