### PR TITLE
Enable plugins to import other plugins.

### DIFF
--- a/disassembler/main.py
+++ b/disassembler/main.py
@@ -4,6 +4,7 @@ import os
 import inspect
 import textwrap
 import itertools
+import sys
 
 from rom import ROM
 from disassembler import Disassembler
@@ -32,12 +33,10 @@ if __name__ == "__main__":
 
     for plugin in args.plugin:
         if os.path.isdir(plugin):
+            sys.path.append(plugin)
             for f in sorted(os.listdir(plugin)):
                 if f.endswith(".py"):
-                    f = os.path.join(plugin, f)
-                    spec = importlib.util.spec_from_file_location("plugin", f)
-                    module = importlib.util.module_from_spec(spec)
-                    spec.loader.exec_module(module)
+                    importlib.import_module(f[:-3])
         else:
             spec = importlib.util.spec_from_file_location("plugin", plugin)
             if spec:


### PR DESCRIPTION
This change makes it possible for files in the plugins directory to import other files in the plugins directory.

I've added this change to my own fork of BadBoy because my project depends on it. I have created this PR in case BadBoy proper would also be interested in it. Comments you've made offline suggest you might prefer not to merge this, so feel free to reject if that's your preference. 