### PR TITLE
Add cli arg for ignoring rom bank instrumentation

### DIFF
--- a/disassembler/instrumentation.py
+++ b/disassembler/instrumentation.py
@@ -22,8 +22,9 @@ MARK_BANK_SHIFT = (48)
 MARK_BANK_MASK = (0xFFF << 48)
 
 
-def processInstrumentation(filename):
+def processInstrumentation(filename, ignore_banks_string):
     f = open(filename, "rb")
+    banks_to_ignore = [int(bank, 16) for bank in ignore_banks_string.split(',')]
     while True:
         data = f.read(16)
         if not data:
@@ -32,6 +33,8 @@ def processInstrumentation(filename):
         if (source & ID_MASK) == ID_ROM:
             addr = source & 0x3FFF
             bank = (source >> 14) & 0x3FF
+            if bank in banks_to_ignore:
+                continue
             if bank > 0:
                 addr |= 0x4000
             

--- a/disassembler/main.py
+++ b/disassembler/main.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
     parser.add_argument("rom", type=str, nargs="?")
     parser.add_argument("--wram-banks", type=int, default=1)
     parser.add_argument("--instrumentation", action='append', default=[])
+    parser.add_argument("--instrumentation-ignore-banks", default="")
     parser.add_argument("--source")
     parser.add_argument("--output", type=str, required=False)
     parser.add_argument("--plugin", action='append', default=[])
@@ -71,7 +72,7 @@ if __name__ == "__main__":
         disassembler = Disassembler(rom, args.wram_banks)
         disassembler.readSources(args.source if args.source else args.output)
         for instrumentation_file in args.instrumentation:
-            processInstrumentation(instrumentation_file)
+            processInstrumentation(instrumentation_file, args.instrumentation_ignore_banks)
         disassembler.processRom()
         if args.output:
             disassembler.export(args.output)


### PR DESCRIPTION
This change adds a command line argument `--instrumentation-ignore-banks`. Its argument is a comma separated list of bank names, i.e. hexadecimal strings. Example: `--instrumentation-ignore-banks 1C,1D,2F,30`. Any instrumentation in the listed banks will be completely ignored.

In my project the instrumentation for banks that were mostly scripts was more hinderance than helpful. Being able to disable instrumentation for those banks was hugely important for automated script parsing. 

This change is merged into my fork of BadBoy, which my project depends on. I crated this PR in case BadBoy main would also be interested in having this. If not, no harm done. Users can workaround this situation by writing a python script to modify their instrumentation files, but I found it nice to not need to. 