### PR TITLE
Fix BadBoy emulator on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,22 @@
 *.app
 
 __pycache__
+
+# ROM files
+*.gb
+*.gbc
+
+# CMake generated
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+CTestTestfile.cmake
+emulator/Makefile
+sweep-emu/Makefile
+
+# Project binaries
+emulator/BadBoy
+sweep-emu/SweepEmu
+
+# Other generated files
+output/

--- a/emulator/src/main.cpp
+++ b/emulator/src/main.cpp
@@ -106,8 +106,19 @@ int main(int argc, char** argv)
     const char* screenshot = nullptr;
     uint32_t max_cycles = 0;
 
+    if (argc > 1 && argv[1][0] != '-') {
+        rom_file = argv[1];
+        optind = 2;
+    }
+
+#ifndef __GLIBC__
+    const char* getopt_opts = "o:r:pe:s:c:S:";
+#else
+    const char* getopt_opts = "-o:r:pe:s:c:S:";
+#endif
+
     int c;
-    while((c = getopt(argc, argv, "-o:r:pe:s:c:S:")) != -1)
+    while((c = getopt(argc, argv, getopt_opts)) != -1)
     {
         switch(c)
         {


### PR DESCRIPTION
GNU extensions aren't available by default, and so this adds in some code that allows it to work with BSD (Posix) getopt.

It additionally adds some patterns to the .gitignore file for easier development.